### PR TITLE
make it work with 20w46a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,15 +6,15 @@ projectArchiveBaseName=shulkerboxtooltip
 refMapName=com.misterpemodder.shulkerboxtooltip.refmap.json
 
 # Fabric Versions
-mcVersion=1.16.4
-mcVersionFull=1.16.4
-yarnMappings=build.1
-fabricLoaderVersion=0.10.6+build.214
-fabricApiVersion=0.25.1+build.416-1.16
+mcVersion=20w46a
+mcVersionFull=20w46a
+yarnMappings=build.13
+fabricLoaderVersion=0.10.8
+fabricApiVersion=0.26.0+1.17
 
 # Dependencies
-modMenuVersion=1.14.6+build.31
-clothConfigVersion=4.8.2
+modMenuVersion=2.0.0-beta.1+build.2
+clothConfigVersion=5.0.0
 autoConfig1uVersion=3.3.1
 libGuiVersion=3.2.1+1.16.3
 

--- a/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/DefaultPreviewRenderer.java
+++ b/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/DefaultPreviewRenderer.java
@@ -1,13 +1,5 @@
 package com.misterpemodder.shulkerboxtooltip.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.PreviewType;
 import com.misterpemodder.shulkerboxtooltip.api.provider.EmptyPreviewProvider;
@@ -16,7 +8,13 @@ import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
 import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration.CompactPreviewTagBehavior;
 import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration.Theme;
 import com.mojang.blaze3d.systems.RenderSystem;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -25,6 +23,7 @@ import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.BufferRenderer;
 import net.minecraft.client.render.DiffuseLighting;
 import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.item.Item;
@@ -207,7 +206,7 @@ public class DefaultPreviewRenderer implements PreviewRenderer {
 
     BufferBuilder builder = Tessellator.getInstance().getBuffer();
 
-    builder.begin(7, VertexFormats.POSITION_TEXTURE);
+    builder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
 
     final double zOffset = 800.0;
     int invSize = this.getInvSize();

--- a/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/DefaultPreviewRenderer.java
+++ b/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/DefaultPreviewRenderer.java
@@ -1,5 +1,13 @@
 package com.misterpemodder.shulkerboxtooltip.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.PreviewType;
 import com.misterpemodder.shulkerboxtooltip.api.provider.EmptyPreviewProvider;
@@ -8,13 +16,7 @@ import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
 import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration.CompactPreviewTagBehavior;
 import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration.Theme;
 import com.mojang.blaze3d.systems.RenderSystem;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
+++ b/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
@@ -2,18 +2,16 @@ package com.misterpemodder.shulkerboxtooltip.mixin.client;
 
 import com.misterpemodder.shulkerboxtooltip.impl.ShulkerBoxTooltipClient;
 import com.misterpemodder.shulkerboxtooltip.impl.hook.ShulkerPreviewPosGetter;
-
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Screen.class)
 public final class ScreenMixin implements ShulkerPreviewPosGetter {
@@ -43,7 +41,8 @@ public final class ScreenMixin implements ShulkerPreviewPosGetter {
   }
 
   @ModifyArg(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;fillGradient"
-      + "(Lnet/minecraft/util/math/Matrix4f;Lnet/minecraft/client/render/BufferBuilder;IIIIIII)V", ordinal = 2), method = "Lnet/minecraft/client/gui/screen/Screen;renderOrderedTooltip"
+      + "(Lnet/minecraft/util/math/Matrix4f;Lnet/minecraft/client/render/BufferBuilder;IIIIIII)V", ordinal = 2), 
+          method = "Lnet/minecraft/client/gui/screen/Screen;method_32633"
           + "(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;II)V", index = 2)
   private int updateTooltipLeftAndBottomPos(Matrix4f matrix, BufferBuilder builder, int x1, int y1, int x2, int y2,
       int zOffset, int color1, int color2) {

--- a/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
+++ b/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
@@ -2,16 +2,18 @@ package com.misterpemodder.shulkerboxtooltip.mixin.client;
 
 import com.misterpemodder.shulkerboxtooltip.impl.ShulkerBoxTooltipClient;
 import com.misterpemodder.shulkerboxtooltip.impl.hook.ShulkerPreviewPosGetter;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.Matrix4f;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Matrix4f;
 
 @Mixin(Screen.class)
 public final class ScreenMixin implements ShulkerPreviewPosGetter {

--- a/src/main/resources/shulkerboxtooltip.client.json
+++ b/src/main/resources/shulkerboxtooltip.client.json
@@ -3,7 +3,7 @@
   "package": "com.misterpemodder.shulkerboxtooltip.mixin.client",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "CreativeInventoryScreenMixin",
+
     "ItemStackMixin",
     "MinecraftClientMixin",
     "ClientPlayNetworkHandlerMixin",


### PR DESCRIPTION
Not too many changes neccesary, updated some version numbers.

It seems like CreativeScreenInventoryMixin isn't neccesary anymore, as there's only one renderTooltip() left, which calls super.renderTooltip() at the end, so ScreenMixin should handle that case. But as I'm not sure, I only removed the reference from the json file without removing the mixin itself.

Also, I didn't change the stuff about Curse tags etc.

Sorry for moving the imports around, my IDE sorts them automatically. I guess if you don't like them it might be easier not to merge the PR, but just take the version numbers from gradle.properties and apply the 3 relevant changes manually (BufferBuilder#begin wants an enum now, ScreenMixin needs a different method name, CreativeScreenInventoryMixin probably needs to go).
