### PR TITLE
Vanilla inclusion promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Shulker Box Tooltip
 
 This mod allows you to see a preview window of a shulker box contents when hovering above it in an inventory by pressing shift.
 
+[Please vote for this to be included in vanilla!](https://feedback.minecraft.net/hc/en-us/community/posts/360074507051-shulker-boxes-should-have-the-new-bundle-interface)
+
 ![](https://i.imgur.com/4JAmlAz.png "Preview Window")
 
 This mod requires Fabric (https://minecraft.curseforge.com/projects/fabric).


### PR DESCRIPTION
In 1.17 snapshot 20w45a, [bundles](https://minecraft.gamepedia.com/Bundle) were added, that let you combine up to 64 items of any kind to one. At first it displayed its contents as a list like the shulker boxes, but in the next snapshot, graphical tooltip was added.

As of 20w51a, the tooltip looks like this (rows and columns change by the amount of items, this is 64 individual ones):
![image](https://user-images.githubusercontent.com/8611110/105572855-5342d880-5d62-11eb-88e5-a5468b2e2dd3.png)

Unfortunately, they still haven't added the same UI to shulker boxes.

So, there is an [idea by the community to do that](https://feedback.minecraft.net/hc/en-us/community/posts/360074507051-shulker-boxes-should-have-the-new-bundle-interface) and I think this mod should help promote it on Github, CurseForge and wherever else you deem appropriate. 
The result would be a win-win: vanilla players would have the feature of this mod and you could either abandon it to focus on more important stuff or continue to improve the vanilla UI instead.  