### PR TITLE
Updated to 1.19.4

### DIFF
--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
@@ -95,13 +95,13 @@ public interface PreviewRenderer {
    *
    * @param x X position of the preview's upper-right corner.
    * @param y Y position of the preview's upper-right corner.
-   * @param z The depth of the preview.
+   * @param z (removed) The depth of the preview.
    * @param matrices The transformation matrices.
    * @param itemRenderer The item renderer.
    * @param textRenderer The text renderer.
    * @param textureManager The texture manager.
    * @since 3.0.0
    */
-  void draw(int x, int y, int z, MatrixStack matrices, TextRenderer textRenderer,
+  void draw(int x, int y, MatrixStack matrices, TextRenderer textRenderer,
       ItemRenderer itemRenderer, TextureManager textureManager);
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
@@ -95,7 +95,6 @@ public interface PreviewRenderer {
    *
    * @param x X position of the preview's upper-right corner.
    * @param y Y position of the preview's upper-right corner.
-   * @param z (removed) The depth of the preview.
    * @param matrices The transformation matrices.
    * @param itemRenderer The item renderer.
    * @param textRenderer The text renderer.

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/network/ClientNetworking.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/network/ClientNetworking.java
@@ -8,7 +8,7 @@ import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/network/ServerNetworking.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/network/ServerNetworking.java
@@ -6,7 +6,7 @@ import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration;
 import com.misterpemodder.shulkerboxtooltip.impl.network.message.S2CEnderChestUpdate;
 import com.misterpemodder.shulkerboxtooltip.impl.network.message.S2CMessages;
 import dev.architectury.injectables.annotations.ExpectPlatform;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/BasePreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/BasePreviewRenderer.java
@@ -11,6 +11,7 @@ import com.misterpemodder.shulkerboxtooltip.impl.util.MergedItemStack;
 import com.misterpemodder.shulkerboxtooltip.impl.util.ShulkerBoxTooltipUtil;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 
@@ -78,7 +79,7 @@ public abstract class BasePreviewRenderer implements PreviewRenderer {
     this.previewContext = context;
   }
 
-  private void drawItem(ItemStack stack, int x, int y, TextRenderer textRenderer,
+  private void drawItem(MatrixStack matrices, ItemStack stack, int x, int y, TextRenderer textRenderer,
     ItemRenderer itemRenderer, int slot, boolean shortItemCount) {
     String countLabel = "";
     int maxRowSize = this.getMaxRowSize();
@@ -94,34 +95,34 @@ public abstract class BasePreviewRenderer implements PreviewRenderer {
     x = this.slotXOffset + x + this.slotWidth * (slot % maxRowSize);
     y = this.slotYOffset + y + this.slotHeight * (slot / maxRowSize);
 
-    itemRenderer.renderInGuiWithOverrides(stack, x, y);
-    itemRenderer.renderGuiItemOverlay(textRenderer, stack, x, y, countLabel);
+    itemRenderer.renderInGuiWithOverrides(matrices, stack , x, y);
+    itemRenderer.renderGuiItemOverlay(matrices, textRenderer, stack, x, y, countLabel);
   }
 
-  protected void drawItems(int x, int y, int z, TextRenderer textRenderer,
+  protected void drawItems(MatrixStack matrices, int x, int y, TextRenderer textRenderer,
     ItemRenderer itemRenderer) {
-    float prevOffset = itemRenderer.zOffset;
+    // float prevOffset = itemRenderer.zOffset;
 
-    itemRenderer.zOffset = z;
+    // itemRenderer.zOffset = z;
 
     try {
       if (this.previewType == PreviewType.COMPACT) {
         boolean shortItemCounts = ShulkerBoxTooltip.config.preview.shortItemCounts;
 
         for (int slot = 0, size = this.items.size(); slot < size; ++slot) {
-          this.drawItem(this.items.get(slot).get(), x, y, textRenderer, itemRenderer, slot,
+          this.drawItem(matrices, this.items.get(slot).get(), x, y, textRenderer, itemRenderer, slot,
             shortItemCounts);
         }
       } else {
         for (MergedItemStack compactor : this.items) {
           for (int slot = 0, size = compactor.size(); slot < size; ++slot) {
-            this.drawItem(compactor.getSubStack(slot), x, y, textRenderer, itemRenderer, slot,
+            this.drawItem(matrices, compactor.getSubStack(slot), x, y, textRenderer, itemRenderer, slot,
               false);
           }
         }
       }
     } finally {
-      itemRenderer.zOffset = prevOffset;
+      // itemRenderer.zOffset = prevOffset;
     }
   }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/BasePreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/BasePreviewRenderer.java
@@ -101,10 +101,7 @@ public abstract class BasePreviewRenderer implements PreviewRenderer {
 
   protected void drawItems(MatrixStack matrices, int x, int y, TextRenderer textRenderer,
     ItemRenderer itemRenderer) {
-    // float prevOffset = itemRenderer.zOffset;
-
-    // itemRenderer.zOffset = z;
-
+      
     try {
       if (this.previewType == PreviewType.COMPACT) {
         boolean shortItemCounts = ShulkerBoxTooltip.config.preview.shortItemCounts;
@@ -122,7 +119,7 @@ public abstract class BasePreviewRenderer implements PreviewRenderer {
         }
       }
     } finally {
-      // itemRenderer.zOffset = prevOffset;
+      
     }
   }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/ModPreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/ModPreviewRenderer.java
@@ -79,8 +79,14 @@ public class ModPreviewRenderer extends BasePreviewRenderer {
     RenderSystem.setShaderTexture(0, texture);
   }
 
-  private void drawBackground(int x, int y, int z, MatrixStack matrices) {
-    int zOffset = z + 100;
+  private void drawBackground(int x, int y, MatrixStack matrices) {
+
+    // May still be possible to use zOffset since .drawTexture() still has a z parameter...
+
+    // pushes copy of top stack and applies translation (will be popped later)
+    matrices.push();
+    matrices.translate(0, 0, 100);
+
     int invSize = this.getInvSize();
     int xOffset = 7;
     int yOffset = 7;
@@ -94,23 +100,23 @@ public class ModPreviewRenderer extends BasePreviewRenderer {
     for (int size = rowSize; size > 0; size -= 9) {
       int s = Math.min(size, 9);
 
-      DrawableHelper.drawTexture(matrices, x + xOffset, y, zOffset, 7, 0, s * 18, 7, 256, 256);
+      DrawableHelper.drawTexture(matrices, x + xOffset, y, 7, 0, s * 18, 7, 256, 256);
       xOffset += s * 18;
     }
 
     while (invSize > 0) {
       xOffset = 7;
       // left side
-      DrawableHelper.drawTexture(matrices, x, y + yOffset, zOffset, 0, rowTexYPos, 7, 18, 256, 256);
+      DrawableHelper.drawTexture(matrices, x, y + yOffset, 0, rowTexYPos, 7, 18, 256, 256);
       for (int rSize = rowSize; rSize > 0; rSize -= 9) {
         int s = Math.min(rSize, 9);
 
         // center
-        DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, zOffset, 7, rowTexYPos, s * 18, 18, 256, 256);
+        DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, 7, rowTexYPos, s * 18, 18, 256, 256);
         xOffset += s * 18;
       }
       // right side
-      DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, zOffset, 169, rowTexYPos, 7, 18, 256, 256);
+      DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, 169, rowTexYPos, 7, 18, 256, 256);
       yOffset += 18;
       invSize -= rowSize;
       rowTexYPos = rowTexYPos >= 43 ? 7 : rowTexYPos + 18;
@@ -121,27 +127,33 @@ public class ModPreviewRenderer extends BasePreviewRenderer {
       int s = Math.min(size, 9);
 
       // bottom side
-      DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, zOffset, 7, 61, s * 18, 7, 256, 256);
+      DrawableHelper.drawTexture(matrices, x + xOffset, y + yOffset, 7, 61, s * 18, 7, 256, 256);
       xOffset += s * 18;
     }
 
     // top-left corner
-    DrawableHelper.drawTexture(matrices, x, y, zOffset, 0, 0, 7, 7, 256, 256);
+    DrawableHelper.drawTexture(matrices, x, y, 0, 0, 7, 7, 256, 256);
     // top-right corner
-    DrawableHelper.drawTexture(matrices, x + rowWidth + 7, y, zOffset, 169, 0, 7, 7, 256, 256);
+    DrawableHelper.drawTexture(matrices, x + rowWidth + 7, y, 169, 0, 7, 7, 256, 256);
     // bottom-right corner
-    DrawableHelper.drawTexture(matrices, x + rowWidth + 7, y + yOffset, zOffset, 169, 61, 7, 7, 256, 256);
+    DrawableHelper.drawTexture(matrices, x + rowWidth + 7, y + yOffset, 169, 61, 7, 7, 256, 256);
     // bottom-left corner
-    DrawableHelper.drawTexture(matrices, x, y + yOffset, zOffset, 0, 61, 7, 7, 256, 256);
+    DrawableHelper.drawTexture(matrices, x, y + yOffset, 0, 61, 7, 7, 256, 256);
+
+    // pops the previous translation operation
+    matrices.pop();
+
+    // reset shader color? for some reason it was shading items aswell...
+    RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
   }
 
   @Override
-  public void draw(int x, int y, int z, MatrixStack matrices, TextRenderer textRenderer, ItemRenderer itemRenderer,
+  public void draw(int x, int y, MatrixStack matrices, TextRenderer textRenderer, ItemRenderer itemRenderer,
       TextureManager textureManager) {
     if (this.items.isEmpty() || this.previewType == PreviewType.NO_PREVIEW)
       return;
     RenderSystem.enableDepthTest();
-    this.drawBackground(x, y, z, matrices);
-    this.drawItems(x, y, z, textRenderer, itemRenderer);
+    this.drawBackground(x, y, matrices);
+    this.drawItems(matrices, x, y, textRenderer, itemRenderer);
   }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
@@ -40,41 +40,41 @@ public class VanillaPreviewRenderer extends BasePreviewRenderer {
   }
 
   @Override
-  public void draw(int x, int y, int z, MatrixStack matrices, TextRenderer textRenderer,
+  public void draw(int x, int y, MatrixStack matrices, TextRenderer textRenderer,
       ItemRenderer itemRenderer, TextureManager textureManager) {
     ++y;
     setTexture();
     RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
     RenderSystem.enableDepthTest();
-    this.drawBackground(x, y, z, this.getColumnCount(), this.getRowCount(), matrices);
-    this.drawItems(x, y, z, textRenderer, itemRenderer);
+    this.drawBackground(x, y, this.getColumnCount(), this.getRowCount(), matrices);
+    this.drawItems(matrices, x, y, textRenderer, itemRenderer);
   }
 
-  private void drawBackground(int x, int y, int z, int columns, int rows, MatrixStack matrices) {
+  private void drawBackground(int x, int y, int columns, int rows, MatrixStack matrices) {
     for (int row = 0; row < rows; ++row) {
       for (int col = 0; col < columns; ++col) {
-        this.drawSprite(matrices, 1 + x + 18 * col, 1 + y + 20 * row, z,
+        this.drawSprite(matrices, 1 + x + 18 * col, 1 + y + 20 * row,
             BundleTooltipComponent.Sprite.SLOT);
       }
     }
-    this.drawSprite(matrices, x, y, z, BundleTooltipComponent.Sprite.BORDER_CORNER_TOP);
-    this.drawSprite(matrices, x + columns * 18 + 1, y, z,
+    this.drawSprite(matrices, x, y, BundleTooltipComponent.Sprite.BORDER_CORNER_TOP);
+    this.drawSprite(matrices, x + columns * 18 + 1, y,
         BundleTooltipComponent.Sprite.BORDER_CORNER_TOP);
     for (int col = 0; col < columns; ++col) {
-      this.drawSprite(matrices, x + 1 + col * 18, y, z,
+      this.drawSprite(matrices, x + 1 + col * 18, y,
           BundleTooltipComponent.Sprite.BORDER_HORIZONTAL_TOP);
-      this.drawSprite(matrices, x + 1 + col * 18, y + rows * 20, z,
+      this.drawSprite(matrices, x + 1 + col * 18, y + rows * 20,
           BundleTooltipComponent.Sprite.BORDER_HORIZONTAL_BOTTOM);
     }
     for (int row = 0; row < rows; ++row) {
-      this.drawSprite(matrices, x, y + row * 20 + 1, z,
+      this.drawSprite(matrices, x, y + row * 20 + 1,
           BundleTooltipComponent.Sprite.BORDER_VERTICAL);
-      this.drawSprite(matrices, x + columns * 18 + 1, y + row * 20 + 1, z,
+      this.drawSprite(matrices, x + columns * 18 + 1, y + row * 20 + 1,
           BundleTooltipComponent.Sprite.BORDER_VERTICAL);
     }
-    this.drawSprite(matrices, x, y + rows * 20, z,
+    this.drawSprite(matrices, x, y + rows * 20,
         BundleTooltipComponent.Sprite.BORDER_CORNER_BOTTOM);
-    this.drawSprite(matrices, x + columns * 18 + 1, y + rows * 20, z,
+    this.drawSprite(matrices, x + columns * 18 + 1, y + rows * 20,
         BundleTooltipComponent.Sprite.BORDER_CORNER_BOTTOM);
   }
 
@@ -85,9 +85,9 @@ public class VanillaPreviewRenderer extends BasePreviewRenderer {
       RenderSystem.setShaderTexture(0, this.textureOverride);
   }
 
-  private void drawSprite(MatrixStack matrices, int x, int y, int z,
+  private void drawSprite(MatrixStack matrices, int x, int y,
       BundleTooltipComponent.Sprite sprite) {
-    DrawableHelper.drawTexture(matrices, x, y, z, sprite.u, sprite.v, sprite.width, sprite.height,
+    DrawableHelper.drawTexture(matrices, x, y, sprite.u, sprite.v, sprite.width, sprite.height,
         128, 128);
   }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PositionAwareTooltipComponent.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PositionAwareTooltipComponent.java
@@ -10,11 +10,11 @@ import javax.annotation.Nullable;
 
 public abstract class PositionAwareTooltipComponent implements TooltipComponent {
   public abstract void drawItems(TextRenderer textRenderer, int x, int y, MatrixStack matrices,
-      ItemRenderer itemRenderer, int z, @Nullable TooltipPosition tooltipPos);
+      ItemRenderer itemRenderer, @Nullable TooltipPosition tooltipPos);
 
   @Override
-  public void drawItems(TextRenderer textRenderer, int x, int y, MatrixStack matrices, ItemRenderer itemRenderer, int z) {
-    this.drawItems(textRenderer, x, y, matrices, itemRenderer, z, null);
+  public void drawItems(TextRenderer textRenderer, int x, int y, MatrixStack matrices, ItemRenderer itemRenderer) {
+    this.drawItems(textRenderer, x, y, matrices, itemRenderer, null);
   }
 
   public record TooltipPosition(Screen screen, int topY, int bottomY) {

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewTooltipComponent.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewTooltipComponent.java
@@ -45,7 +45,7 @@ public class PreviewTooltipComponent extends PositionAwareTooltipComponent {
 
   @Override
   public void drawItems(TextRenderer textRenderer, int x, int y, MatrixStack matrices,
-      ItemRenderer itemRenderer, int z, @Nullable TooltipPosition tooltipPos) {
+      ItemRenderer itemRenderer, @Nullable TooltipPosition tooltipPos) {
     renderer.setPreview(this.context, this.provider);
     renderer.setPreviewType(
       ShulkerBoxTooltipApi.getCurrentPreviewType(this.provider.isFullPreviewAvailable(this.context)));
@@ -63,6 +63,6 @@ public class PreviewTooltipComponent extends PositionAwareTooltipComponent {
           || (position == PreviewPosition.OUTSIDE && y + h > screen.height))
         y = tooltipPos.topY() - h;
     }
-    this.renderer.draw(x, y, z, matrices, textRenderer, itemRenderer, MinecraftClient.getInstance().getTextureManager());
+    this.renderer.draw(x, y, matrices, textRenderer, itemRenderer, MinecraftClient.getInstance().getTextureManager());
   }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/util/DefaultedTranslatableText.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/util/DefaultedTranslatableText.java
@@ -13,14 +13,14 @@ public class DefaultedTranslatableText extends TranslatableTextContent {
   private final String defaultString;
   private final StringVisitable defaultStringRenderable;
 
-  public DefaultedTranslatableText(String key, String defaultString) {
-    super(key);
-    this.defaultString = defaultString;
-    this.defaultStringRenderable = StringVisitable.plain(defaultString);
-  }
+  // public DefaultedTranslatableText(String key, String defaultString) {
+  //   super(key);
+  //   this.defaultString = defaultString;
+  //   this.defaultStringRenderable = StringVisitable.plain(defaultString);
+  // }
 
   public DefaultedTranslatableText(String key, String defaultString, Object... args) {
-    super(key, args);
+    super(key, null, args);
     this.defaultString = defaultString;
     this.defaultStringRenderable = StringVisitable.plain(defaultString);
   }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/mixin/client/ScreenMixin.java
@@ -36,17 +36,17 @@ public class ScreenMixin {
 
   @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/tooltip/TooltipComponent;drawItems"
       + "(Lnet/minecraft/client/font/TextRenderer;IILnet/minecraft/client/util/math/MatrixStack;"
-      + "Lnet/minecraft/client/render/item/ItemRenderer;I)V"), method =
+      + "Lnet/minecraft/client/render/item/ItemRenderer;)V"), method =
       "Lnet/minecraft/client/gui/screen/Screen;renderTooltipFromComponents"
           + "(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;"
           + "IILnet/minecraft/client/gui/tooltip/TooltipPositioner;)V")
   private void drawPosAwareComponent(TooltipComponent component, TextRenderer textRenderer, int x, int y,
-      MatrixStack matrices, ItemRenderer itemRenderer, int z) {
+      MatrixStack matrices, ItemRenderer itemRenderer) {
     if (component instanceof PositionAwareTooltipComponent posAwareComponent) {
       //noinspection ConstantConditions
-      posAwareComponent.drawItems(textRenderer, x, y, matrices, itemRenderer, z,
+      posAwareComponent.drawItems(textRenderer, x, y, matrices, itemRenderer,
           new TooltipPosition((Screen) (Object) this, this.shulkerboxtooltip$topY, this.shulkerboxtooltip$bottomY));
     } else
-      component.drawItems(textRenderer, x, y, matrices, itemRenderer, z);
+      component.drawItems(textRenderer, x, y, matrices, itemRenderer);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,18 +5,18 @@ projectDescription=Adds a display of shulker box contents
 projectArchiveBaseName=shulkerboxtooltip
 
 # Minecraft
-mcVersion=1.19.3
-mcVersionFull=1.19.3
-yarnMappings=build.3
+mcVersion=1.19.4
+mcVersionFull=1.19.4
+yarnMappings=build.1
 
 # Mod Loaders
 enabledPlatforms=fabric,forge
-fabricLoaderVersion=0.14.11
-fabricApiVersion=0.69.0+1.19.3
-forgeVersion=1.19.3-44.0.11
+fabricLoaderVersion=0.14.17
+fabricApiVersion=0.76.0+1.19.4
+forgeVersion=1.19.4-45.0.1
 
 # Dependencies
-modMenuVersion=5.0.0-alpha.4
+modMenuVersion=6.1.0-rc.1
 clothConfigVersion=9.0.94
 
 # Maven Metadata
@@ -24,7 +24,7 @@ pomName=Shulker Box Tooltip
 gitLink=MisterPeModder/ShulkerBoxTooltip
 
 # Hosting Platforms
-hostGameVersions=1.19.3
+hostGameVersions=1.19.4
 curseProjectId=315811
 modrinthProjectId=2M01OLQq
 


### PR DESCRIPTION
- Packet changed to packet.Packet
- Removed most instances of "int zOffset" or "int z" and replaced with MatrixStack operation
- Reset ShaderColor at end of drawBackground() since it shaded items for some reason
- Commented out DefaultedTranslatableText constructor with "super(key)"
- Added "null" to DefaultedTranslatableText
- Removed z component of drawPosAwareComponent of ScreenMixin class (removed the ' I ' character too)

Have not tested the VanillaPreviewRenderer since that seems to be called due to changed config and I could not get it to work.
