### PR TITLE
Bundle Outside Preview Render

### DIFF
--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/api/renderer/PreviewRenderer.java
@@ -134,4 +134,30 @@ public interface PreviewRenderer {
       int mouseY) {
     this.draw(x, y, graphics, font, mouseX, mouseY);
   }
+
+  /**
+   * Returns the X-axis offset applied to the preview when it is rendered outside the tooltip
+   * (i.e. when the preview position is {@code OUTSIDE_TOP} or {@code OUTSIDE_BOTTOM}).
+   * <p>
+   * The default implementation returns {@code 0} (no adjustment).
+   *
+   * @return the X offset in pixels.
+   * @since 5.4.0
+   */
+  default int getOutsideXOffset() {
+    return 0;
+  }
+
+  /**
+   * Returns the Y-axis offset between the tooltip and the preview when it is rendered outside the
+   * tooltip (i.e. when the preview position is {@code OUTSIDE_TOP} or {@code OUTSIDE_BOTTOM}).
+   * <p>
+   * The default implementation returns {@code 0} (no adjustment).
+   *
+   * @return the Y offset in pixels.
+   * @since 5.4.0
+   */
+  default int getOutsideYOffset() {
+    return 0;
+  }
 }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/ModPreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/ModPreviewRenderer.java
@@ -27,6 +27,16 @@ public class ModPreviewRenderer extends BasePreviewRenderer {
   }
 
   @Override
+  public int getOutsideXOffset() {
+    return -4;
+  }
+
+  @Override
+  public int getOutsideYOffset() {
+    return 4;
+  }
+
+  @Override
   public int getWidth() {
     return 14 + Math.min(this.getMaxRowSize(), this.getInvSize()) * 18;
   }

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
@@ -31,6 +31,15 @@ public class VanillaPreviewRenderer extends BasePreviewRenderer {
     super(24, 24, 0, 0);
   }
 
+  @Override
+  public int getOutsideXOffset() {
+    return 0;
+  }
+
+  @Override
+  public int getOutsideYOffset() {
+    return 8;
+  }
 
   @Override
   protected int getMaxRowSize() {

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/renderer/VanillaPreviewRenderer.java
@@ -7,9 +7,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.inventory.tooltip.TooltipRenderUtil;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
+import com.misterpemodder.shulkerboxtooltip.ShulkerBoxTooltip;
+import com.misterpemodder.shulkerboxtooltip.impl.config.Configuration.PreviewPosition;
 
 @Environment(EnvType.CLIENT)
 public class VanillaPreviewRenderer extends BasePreviewRenderer {
@@ -76,6 +79,12 @@ public class VanillaPreviewRenderer extends BasePreviewRenderer {
       return;
 
     x += (viewportWidth - this.getWidth()) / 2; // Align center
+
+    PreviewPosition pos = ShulkerBoxTooltip.config.preview.position;
+    if (pos == PreviewPosition.OUTSIDE || pos == PreviewPosition.OUTSIDE_TOP || pos == PreviewPosition.OUTSIDE_BOTTOM) {
+      TooltipRenderUtil.extractTooltipBackground(graphics, x, y, this.getWidth(), this.getHeight(), null);
+    }
+
     this.drawSlots(x, y, graphics, font, mouseX, mouseY, this.lastNonEmptySlot);
     this.drawInnerTooltip(x, y, graphics, font, mouseX, mouseY);
     this.drawSelectedItemTooltip(viewportWidth, graphics, font);

--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewClientTooltipComponent.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewClientTooltipComponent.java
@@ -65,11 +65,11 @@ public class PreviewClientTooltipComponent implements ClientTooltipComponent {
     }
 
     if (position == PreviewPosition.OUTSIDE_TOP) {
-      x -= 4;
-      y = tooltipTopY - viewportHeight - 4;
+      x += this.renderer.getOutsideXOffset();
+      y = tooltipTopY - viewportHeight - this.renderer.getOutsideYOffset();
     } else if (position == PreviewPosition.OUTSIDE_BOTTOM) {
-      x -= 4;
-      y = tooltipTopY + totalHeight + 4;
+      x += this.renderer.getOutsideXOffset();
+      y = tooltipTopY + totalHeight + this.renderer.getOutsideYOffset();
     }
 
     this.renderer.draw(x, y, totalWidth, viewportHeight, graphics, font, mouseX, mouseY);


### PR DESCRIPTION
- bundle preview render when outside tooltip now draws its own background
- adjusted outside preview render offset to not overlap with the tooltip render as was happening before for vanilla-style render
- addressing partially issue #249