### PR TITLE
Preview Collision on Edge Handle

### DIFF
--- a/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewClientTooltipComponent.java
+++ b/common/src/main/java/com/misterpemodder/shulkerboxtooltip/impl/tooltip/PreviewClientTooltipComponent.java
@@ -53,15 +53,17 @@ public class PreviewClientTooltipComponent implements ClientTooltipComponent {
     int tooltipTopY = extendedGraphics.getTooltipTopYPosition();
 
     PreviewPosition position = ShulkerBoxTooltip.config.preview.position;
+    boolean autoPosition = position == PreviewPosition.OUTSIDE;
     int viewportHeight = this.renderer.getHeight();
+    int screenHeight = graphics.guiHeight();
+    int screenWidth = graphics.guiWidth();
 
     if (tooltipTopY == Integer.MIN_VALUE)
       // Fall back to "inside" if the tooltip Y position was not captured
       position = PreviewPosition.INSIDE;
 
     if (position == PreviewPosition.OUTSIDE) {
-      int screenH = graphics.guiHeight();
-      position = tooltipTopY + totalHeight + viewportHeight > screenH ?
+      position = tooltipTopY + totalHeight + viewportHeight > screenHeight ?
           PreviewPosition.OUTSIDE_TOP :
           PreviewPosition.OUTSIDE_BOTTOM;
     }
@@ -72,6 +74,42 @@ public class PreviewClientTooltipComponent implements ClientTooltipComponent {
     } else if (position == PreviewPosition.OUTSIDE_BOTTOM) {
       x += this.renderer.getOutsideXOffset();
       y = tooltipTopY + totalHeight + this.renderer.getOutsideYOffset();
+    }
+
+    if (position == PreviewPosition.OUTSIDE_TOP || position == PreviewPosition.OUTSIDE_BOTTOM) {
+      if (y < 0 || y + viewportHeight > screenHeight) {
+        boolean resolved = false;
+
+        if (autoPosition) {
+          int yOffset = this.renderer.getOutsideYOffset();
+          int yFlipped = position == PreviewPosition.OUTSIDE_BOTTOM ?
+              tooltipTopY - viewportHeight - yOffset :
+              tooltipTopY + totalHeight + yOffset;
+
+          if (yFlipped >= 0 && yFlipped + viewportHeight <= screenHeight) {
+            y = yFlipped;
+            resolved = true;
+          }
+        }
+
+        if (!resolved) {
+          int previewWidth = this.renderer.getWidth();
+          final int sideGap = 24;
+          boolean tooltipLeftOfCursor = tooltipTopX + totalWidth / 2 < mouseX;
+
+          if (tooltipLeftOfCursor)
+            x = Math.min(tooltipTopX + totalWidth + sideGap, screenWidth - previewWidth);
+          else
+            x = Math.max(tooltipTopX - previewWidth - sideGap, 0);
+
+          y = tooltipTopY + (totalHeight - viewportHeight) / 2;
+          y = Math.min(Math.max(y, 0), screenHeight - viewportHeight);
+
+          totalWidth = previewWidth;
+          tooltipTopX = x;
+          tooltipTopY = y;
+        }
+      }
     }
 
     this.renderer.draw(


### PR DESCRIPTION
- when the container is to tall (large height) so it gets partially cut off the viewport and preview position is set somewhere outside the tooltip (only then that happens since inside handles collision by the tooltip render), then move the preview render to the other side of the cursor from the one the tooltip is rendered
- preview render now can stop moving outside viewport when reaching edge without affecting tooltip render
- experimental and no well tested
- potentially addressing partially issue #247

(demonstration outside bottom)
<img width="1068" height="613" alt="demo outside bottom" src="https://github.com/user-attachments/assets/0b3f0f87-e9e1-4c8b-9cdd-16264f39b1b8" />
